### PR TITLE
Update README.md for `go run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Download the latest version of the [toolset](https://github.com/token2/authy-mig
 Unzip to a folder, launch command line and change folder to {path}/cmd/authy-export and launch the command
 
 ```shell
-go run authy-export.go
+go run cmd/authy-export/authy-export.go
 ```
 
 **To use it:**


### PR DESCRIPTION
```
authy-migration-master%% go run authy-export.go
stat authy-export.go: no such file or directory
```

vs 
```
authy-migration-master%% go run cmd/authy-export/authy-export.go
go: downloading golang.org/x/sys v0.0.0-20190412213103-97732733099d

Export file name:....
```