### PR TITLE
Add support for exporting in Raivo JSON format for 2FAS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Forked from [![GoDoc](https://godoc.org/github.com/alexzorin/authy?status.svg)](
 
 This is a Go library that allows you to access your [Authy](https://authy.com) TOTP tokens.
 
-It was created to facilitate migrating from Authy to Token2 hardware tokens (including Molto2 multi-profile TOTP hardware token) or other TOTP Apps. Additionally, it supports exporting profiles to [WinAuth](https://winauth.github.io/winauth/index.html), a desktop TOTP app.
+It was created to facilitate migrating from Authy to Token2 hardware tokens (including Molto2 multi-profile TOTP hardware token) or other TOTP Apps. Additionally, it supports exporting profiles to [WinAuth](https://winauth.github.io/winauth/index.html), a desktop TOTP app, and as Raivo JSON export which can be imported by, say, [2FAS](https://2fas.com) an Open Source app for iOS and Android.
 
 
 Please note that this tool only migrates non-Authy-hosted accounts (the ones that are generating 7-digit OTP with 10/20 seconds intervals). The tool is intended to migrate "standard" TOTP profiles: 6 or 8 digits, 30 seconds (Authy app supports only 30 seconds TOTP profiles in addition to its native accounts).
@@ -53,7 +53,7 @@ go run git clone https://github.com/token2/authy-migration.git
 3. If the program identifies an existing Authy account, it will send a device registration request using the `push` method. This will send a push notification to your existing Authy apps (be it on Android, iOS, Desktop or Chrome), and you will need to respond that from your other app(s).
 4. If the device registration is successful, the program will save its authentication credential (a random value) to `$HOME/authy-go.json` for further uses. **Make sure to delete this file and de-register the device after you're finished.**
 5. If the program is able to fetch your TOTP encrypted database, it will prompt you for your Authy backup password. This is required to decrypt the TOTP secrets for the next step. 
-6. The program will dump all of your TOTP tokens in a file in the same folder: a **.txt** file which can be used for importing to Molto2 directly, or an **.html** file with QR codes, which you can use to import to other applications. If you plan to import the TOTP profiles exported from Authy to WinAuth, the filename should end with **.wa.txt** extension.
+6. The program will dump all of your TOTP tokens in a file in the same folder: a **.txt** file which can be used for importing to Molto2 directly, or an **.html** file with QR codes, which you can use to import to other applications. If you plan to import the TOTP profiles exported from Authy to WinAuth, the filename should end with **.wa.txt** extension. For Raivo export the program will create a **.raivos** file which you rename to **.json** after possibly editing it to adjust account names.
 
 ## Third-party modules
 The module below is used for generating QR codes

--- a/cmd/authy-export/authy-export.go
+++ b/cmd/authy-export/authy-export.go
@@ -31,14 +31,17 @@ type deviceRegistration struct {
 
 // Struct for Raivo JSON format
 type raivo struct {
-        Digits  string `json:"digits"`
-        Kind    string `json:"kind"`
-        Algo    string `json:"algorithm"`
-        Counter string `json:"counter"`
-        Timer   string `json:"timer"`
-        Secret  string `json:"secret"`
-        Account string `json:"account"`
-        Issuer  string `json:"issuer"`
+	Digits  string `json:"digits"`
+	Kind    string `json:"kind"`
+	Algo    string `json:"algorithm"`
+	Counter string `json:"counter"`
+	Timer   string `json:"timer"`
+	Secret  string `json:"secret"`
+	Account string `json:"account"`
+	Issuer  string `json:"issuer"`
+	Icontype string `json:"iconType"`
+	Iconvalue string `json:"iconValue"`
+	Pinned  string `json:"pinned"`
 }
 
 
@@ -193,7 +196,10 @@ func main() {
 				Timer:   "30",
 				Secret:  decrypted,
 				Account: "authy-export",
-				Issuer:  tok.Description()})
+				Issuer:  tok.Description(),
+				Icontype: "",
+				Iconvalue: "",
+				Pinned: "false"})
 		}
 
 		if (last6 == "wa.txt") {


### PR DESCRIPTION
This patch adds support for exporting as `*.raivos` (which ought to be called `.json`, but I thought that would be too all-encompassing). I have used this to import my Authy-exported tokens into the [2FAS open source](https://2fas.com) apps.

A file named `*.raivos` is created and can then be edited, say to adjust the descriptions etc. It contains an array of JSON dicts:

```json
[
   {
      "digits": "6",
      "kind": "TOTP",
      "algorithm": "SHA1",
      "counter": "0",
      "timer": "30",
      "secret": "MFRHEYLDMFSGCYTSMEYDAMBR",
      "account": "authy-export",
      "issuer": "Alibaba (authenticator)"
   }
]
```

I've set `issuer` to the name of the Authy token, and `account` to the constant string `authy-export`; I change the latter to, say, the email address I used for a particulary account.